### PR TITLE
Cache packages in CI

### DIFF
--- a/.github/workflows/arduino_build.yml
+++ b/.github/workflows/arduino_build.yml
@@ -5,10 +5,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: arduino/setup-arduino-cli@v1
+      - name: Cache Arduino packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.arduino15/packages
+            ~/Arduino/packages
+      - uses: arduino/setup-arduino-cli@v1    
       - run: |
-          arduino-cli core update-index --additional-urls https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
-          arduino-cli core install esp32:esp32 --additional-urls https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+          arduino-cli core update-index --additional-urls https://espressif.github.io/arduino-esp32/package_esp32_index.json
+          arduino-cli core install esp32:esp32 --additional-urls https://espressif.github.io/arduino-esp32/package_esp32_index.json
           arduino-cli lib install AutoConnect
       - run: cd test152; arduino-cli compile --fqbn esp32:esp32:esp32s2 --output-dir build
       - name: Upload bin


### PR DESCRIPTION
Instead of RAW, use the public CDN version of the file for faster downloads.

@tarxvftech This PR adds the CI caching of the packages.